### PR TITLE
Feature/client cleanup

### DIFF
--- a/examples/client_autobahn.c
+++ b/examples/client_autobahn.c
@@ -56,7 +56,6 @@ void runTest(void)
 
   websocketInit.port = "9001";
   websocketInit.address = "127.0.0.1";
-  websocketInit.hostname = "arc";
   websocketInit.ws_onOpen = onOpen;
   websocketInit.ws_onClose = onClose;
   websocketInit.ws_onMessage = onMessage;

--- a/examples/client_chat.c
+++ b/examples/client_chat.c
@@ -68,7 +68,6 @@ void runTest(void)
   websocketInit.port = "443";
   websocketInit.address = "192.168.200.12";
   //websocketInit.address = "20.52.121.234";
-  websocketInit.hostname = "arc";
   websocketInit.ws_onOpen = onOpen;
   websocketInit.ws_onClose = onClose;
   websocketInit.ws_onMessage = onMessage;

--- a/examples/client_chat.c
+++ b/examples/client_chat.c
@@ -58,20 +58,16 @@ void runTest(void)
 {
   struct websocket_client_init websocketInit = { 0 };
   struct websocket_connection_desc *wsConnectionDesc;
-  //char *msg = "test";
   char msg[4] = { 0x08, 0xCB, 0x00, 0x00 };
   
 
   int i = 12, rc = 0;
 
-  //websocketInit.port = "5000";
   websocketInit.port = "443";
   websocketInit.address = "192.168.200.12";
-  //websocketInit.address = "20.52.121.234";
   websocketInit.ws_onOpen = onOpen;
   websocketInit.ws_onClose = onClose;
   websocketInit.ws_onMessage = onMessage;
- // websocketInit.endpoint = strdup("/ws");;
   websocketInit.endpoint = strdup("/xxx");;
   websocketInit.keepalive = true;
   websocketInit.keep_idle_sec = 10;
@@ -84,7 +80,6 @@ void runTest(void)
   {
       if(i-- < 0)
       {
-    //    rc = websocket_sendData(wsConnectionDesc, WS_DATA_TYPE_TEXT, msg, strlen(msg));
         rc = websocket_sendData(wsConnectionDesc, WS_DATA_TYPE_BINARY, msg, sizeof(msg));
 	i = 12;
       }

--- a/include/ezwebsocket.h
+++ b/include/ezwebsocket.h
@@ -115,8 +115,6 @@ struct websocket_client_init
   const char *address;
   //! the port of the remote target
   const char *port;
-  //! the hostname that should be used
-  const char *hostname;
   //! the endpoint of the remote (e.g. /chat)
   const char *endpoint;
     //! Enable or disable keepalive


### PR DESCRIPTION
The unused and therefore confusing hostname member has been removed from the client initialization structure.
And also removed some commented out fragments.

Note: Client applications that used the hostname member (for whatever reason) need to make adjustments.