### PR TITLE
socket_client: TLS/SSL handshake error handling

### DIFF
--- a/lib/socket_client/socket_client.c
+++ b/lib/socket_client/socket_client.c
@@ -309,7 +309,10 @@ socketClient_open(struct socket_client_init *socketInit, void *socketUserData)
     socketDesc->ssl_ctx = SSL_CTX_new(SSLv23_method());
     socketDesc->ssl = SSL_new(socketDesc->ssl_ctx);
     SSL_set_fd(socketDesc->ssl, socketDesc->socketFd);
-    SSL_connect(socketDesc->ssl);
+    if (SSL_connect(socketDesc->ssl) != 1) {
+      ezwebsocket_log(EZLOG_ERROR, "TLS/SSL handshake failed\n");
+      goto ERROR;
+    }
   }
 #else
   if (socketInit->secure) {


### PR DESCRIPTION
Check if SSL_connect fails and handle the possible error accordinly.
SSL_connect returns 1 on success and 0 or ret < 0 on failure.