### PR TITLE
socket_client: connection log level to Warning

### DIFF
--- a/lib/ezwebsocket.c
+++ b/lib/ezwebsocket.c
@@ -1783,7 +1783,7 @@ websocketClient_open(struct websocket_client_init *wsInit, void *websocketUserDa
 
   wsConnection->socketClientDesc = socketClient_open(&socketInit, wsConnection);
   if (!wsConnection->socketClientDesc) {
-    ezwebsocket_log(EZLOG_ERROR, "socketClient_open failed\n");
+    ezwebsocket_log(EZLOG_WARNING, "socketClient_open failed\n");
     goto ERROR;
   }
 

--- a/lib/socket_client/socket_client.c
+++ b/lib/socket_client/socket_client.c
@@ -278,7 +278,7 @@ socketClient_open(struct socket_client_init *socketInit, void *socketUserData)
 
   // Connect to remote server
   if (connect(socketDesc->socketFd, (struct sockaddr *) &server, sizeof(server)) < 0) {
-    ezwebsocket_log(EZLOG_ERROR, "connection failed\n");
+    ezwebsocket_log(EZLOG_WARNING, "connection failed\n");
     goto ERROR;
   }
 


### PR DESCRIPTION
Required to avoid periodic error logging if Calling Home is active and Management Hub is not reachable. it only affects the client side of the socket opening operation.